### PR TITLE
Fix Gemini retry handling

### DIFF
--- a/gemini_client.py
+++ b/gemini_client.py
@@ -102,7 +102,11 @@ class GeminiClient:
                 text_response = text_response[:-3]
 
             return text_response
+        except google_exceptions.GoogleAPIError:
+            # Propagate Google API errors so the tenacity retry decorator can
+            # handle them properly.
+            raise
         except Exception as exc:
             raise RuntimeError(
                 f"Failed to generate content with Gemini API model: {exc}"
-            ) from exc 
+            ) from exc


### PR DESCRIPTION
## Summary
- allow GeminiClient to propagate Google API errors for retry

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6855b0750070832d956daaf22b626d34